### PR TITLE
The AWS provided policy for ECS is `AmazonECSTaskExecutionRolePolicy`

### DIFF
--- a/docs/orchestration/agents/ecs.md
+++ b/docs/orchestration/agents/ecs.md
@@ -149,7 +149,7 @@ behalf. If actions taken to _start_ your task require external AWS services
 Permissions used by your code once your task starts are granted via [task
 roles](#task-role-arn) instead (see above).
 
-ECS provides a builtin policy `AmazonECSTaskExecutionPolicy` that provides
+ECS provides a builtin policy `AmazonECSTaskExecutionRolePolicy` that provides
 common settings. This supports pulling images from ECR and enables using
 CloudWatch logs. The full policy is below:
 


### PR DESCRIPTION
The AWS provided policy for ECS is `AmazonECSTaskExecutionRolePolicy` not `AmazonECSTaskExecutionPolicy`

see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html

## Summary

Corrects the name of the policy - raised in https://github.com/PrefectHQ/prefect/issues/5225

## Changes

The name of the policy to what AWS docs list


## Importance

Would result in people trying an non-existent policy if they followed this part of the docs


## Checklist

This PR:

- [x] adds new tests (if appropriate) (N/A)
- [x] adds a change file in the `changes/` directory (if appropriate) - not needed IMO
- [x] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)